### PR TITLE
fix: relay buffer leak on UDP read error

### DIFF
--- a/relay/relay.go
+++ b/relay/relay.go
@@ -187,6 +187,8 @@ func (s *UDPProxyServer) readPackets() {
 		n, remoteAddr, err := s.conn.ReadFromUDP(buf)
 		if err != nil {
 			logger.Error("Error reading UDP packet: %v", err)
+			// Return buffer to pool on read error to avoid leaks
+			bufferPool.Put(buf[:1500])
 			continue
 		}
 		s.packetChan <- Packet{data: buf[:n], remoteAddr: remoteAddr, n: n}


### PR DESCRIPTION
## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## Description

When ReadFromUDP fails in readPackets, the buffer was not returned to the sync.Pool, causing a small but persistent leak under error conditions. Return the buffer before continuing to ensure reuse and stable memory.

Scope: minimal hotfix (no broader refactors) based on my other branch that extensively updated relay.go

## How to test?

Difficult but on error the buffer should be placed back into the pool instead of silently leaking as the sync.Pool cannot track its lifecycle as under error it believes the buffer is in use.
