### PR TITLE
feat: optimize calculatePeerBandwidth to avoid nested loops

### DIFF
--- a/main.go
+++ b/main.go
@@ -639,7 +639,7 @@ func ensureMSSClamping() error {
 		if out, err := addCmd.CombinedOutput(); err != nil {
 			errMsg := fmt.Sprintf("Failed to add MSS clamping rule for chain %s: %v (output: %s)",
 				chain, err, string(out))
-			logger.Error("%s", errMsg)
+			logger.Error(errMsg)
 			errors = append(errors, fmt.Errorf("%s", errMsg))
 			continue
 		}
@@ -656,7 +656,7 @@ func ensureMSSClamping() error {
 		if out, err := checkCmd.CombinedOutput(); err != nil {
 			errMsg := fmt.Sprintf("Rule verification failed for chain %s: %v (output: %s)",
 				chain, err, string(out))
-			logger.Error("%s", errMsg)
+			logger.Error(errMsg)
 			errors = append(errors, fmt.Errorf("%s", errMsg))
 			continue
 		}


### PR DESCRIPTION
## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## Description

Build a set of current peer public keys during the primary iteration and prune lastReadings in a single pass, removing the O(n^2) nested loop.

## How to test?

No behavior change; improves efficiency when peer lists and lastReadings grow large.

Whole function example calculation

With 5 peers:

old: 5 (primary) + O(5^2) = 30 passes
new: 5 (primary) + 5 (Secondary) = 10 passes

_calculation are presumption pass loops had 5 peers and new iteration has same 5 peers_