### PR TITLE
feat: websocket relay

### DIFF
--- a/main.go
+++ b/main.go
@@ -1665,6 +1665,10 @@ func ensureIFBDevice() error {
 // Bandwidth limit is configurable via the --bandwidth-limit flag or BANDWIDTH_LIMIT env var (default: 50mbit)
 func setupPeerBandwidthLimit(peerIP string) error {
 	logger.Debug("setupPeerBandwidthLimit called for peer IP: %s", peerIP)
+<<<<<<< HEAD
+=======
+
+>>>>>>> 06969a4 (Add var for b limit)
 
 	// Parse the IP to get just the IP address (strip any CIDR notation if present)
 	ip := peerIP

--- a/main.go
+++ b/main.go
@@ -34,16 +34,16 @@ import (
 )
 
 var (
-	interfaceName string
-	listenAddr    string
-	mtuInt        int
-	lastReadings  = make(map[string]PeerReading)
-	mu            sync.Mutex
-	wgMu          sync.Mutex // Protects WireGuard operations
-	notifyURL     string
-	proxyRelay    *relay.UDPProxyServer
-	proxyTCPRelay *relay.TCPProxyServer
-	proxySNI      *proxy.SNIProxy
+	interfaceName    string
+	listenAddr       string
+	mtuInt           int
+	lastReadings     = make(map[string]PeerReading)
+	mu               sync.Mutex
+	wgMu             sync.Mutex // Protects WireGuard operations
+	notifyURL        string
+	proxyRelay       *relay.UDPProxyServer
+	proxyWssRelay    *relay.WssRelayServer
+	proxySNI         *proxy.SNIProxy
 	doTrafficShaping bool
 	bandwidthLimit   string
 	ifbName          string // IFB device name for ingress traffic shaping
@@ -162,7 +162,7 @@ func main() {
 		logLevel             string
 		mtu                  string
 		sniProxyPort         int
-		tcpRelayPort         int
+		wssRelayPort         int
 		localProxyAddr       string
 		localProxyPort       int
 		localOverridesStr    string
@@ -275,7 +275,7 @@ func main() {
 	if sniProxyPortStr == "" {
 		flag.IntVar(&sniProxyPort, "sni-port", 8443, "Port to listen on")
 	}
-	flag.IntVar(&tcpRelayPort, "tcp-relay-port", 4430, "Port for internal TCP relay listener")
+	flag.IntVar(&wssRelayPort, "wss-relay-port", 4430, "Port for internal WSS relay bridge listener")
 
 	if localProxyAddr == "" {
 		flag.StringVar(&localProxyAddr, "local-proxy", "localhost", "Local proxy address")
@@ -507,12 +507,12 @@ func main() {
 	}
 	defer proxyRelay.Stop()
 
-	proxyTCPRelay = relay.NewTCPProxyServer(groupCtx, fmt.Sprintf(":%d", tcpRelayPort), proxyRelay)
-	err = proxyTCPRelay.Start()
+	proxyWssRelay = relay.NewWssRelayServer(groupCtx, fmt.Sprintf(":%d", wssRelayPort), proxyRelay)
+	err = proxyWssRelay.Start()
 	if err != nil {
-		logger.Fatal("Failed to start TCP relay server: %v", err)
+		logger.Fatal("Failed to start WSS relay server: %v", err)
 	}
-	defer proxyTCPRelay.Stop()
+	defer proxyWssRelay.Stop()
 
 	// TODO: WE SHOULD PULL THIS OUT OF THE CONFIG OR SOMETHING
 	// 		 SO YOU DON'T NEED TO SET THIS SEPARATELY
@@ -585,8 +585,8 @@ func main() {
 		if proxyRelay != nil {
 			proxyRelay.Stop()
 		}
-		if proxyTCPRelay != nil {
-			proxyTCPRelay.Stop()
+		if proxyWssRelay != nil {
+			proxyWssRelay.Stop()
 		}
 		return nil
 	})

--- a/main.go
+++ b/main.go
@@ -34,15 +34,16 @@ import (
 )
 
 var (
-	interfaceName    string
-	listenAddr       string
-	mtuInt           int
-	lastReadings     = make(map[string]PeerReading)
-	mu               sync.Mutex
-	wgMu             sync.Mutex // Protects WireGuard operations
-	notifyURL        string
-	proxyRelay       *relay.UDPProxyServer
-	proxySNI         *proxy.SNIProxy
+	interfaceName string
+	listenAddr    string
+	mtuInt        int
+	lastReadings  = make(map[string]PeerReading)
+	mu            sync.Mutex
+	wgMu          sync.Mutex // Protects WireGuard operations
+	notifyURL     string
+	proxyRelay    *relay.UDPProxyServer
+	proxyTCPRelay *relay.TCPProxyServer
+	proxySNI      *proxy.SNIProxy
 	doTrafficShaping bool
 	bandwidthLimit   string
 	ifbName          string // IFB device name for ingress traffic shaping
@@ -161,6 +162,7 @@ func main() {
 		logLevel             string
 		mtu                  string
 		sniProxyPort         int
+		tcpRelayPort         int
 		localProxyAddr       string
 		localProxyPort       int
 		localOverridesStr    string
@@ -273,6 +275,7 @@ func main() {
 	if sniProxyPortStr == "" {
 		flag.IntVar(&sniProxyPort, "sni-port", 8443, "Port to listen on")
 	}
+	flag.IntVar(&tcpRelayPort, "tcp-relay-port", 4430, "Port for internal TCP relay listener")
 
 	if localProxyAddr == "" {
 		flag.StringVar(&localProxyAddr, "local-proxy", "localhost", "Local proxy address")
@@ -504,6 +507,13 @@ func main() {
 	}
 	defer proxyRelay.Stop()
 
+	proxyTCPRelay = relay.NewTCPProxyServer(groupCtx, fmt.Sprintf(":%d", tcpRelayPort), proxyRelay)
+	err = proxyTCPRelay.Start()
+	if err != nil {
+		logger.Fatal("Failed to start TCP relay server: %v", err)
+	}
+	defer proxyTCPRelay.Stop()
+
 	// TODO: WE SHOULD PULL THIS OUT OF THE CONFIG OR SOMETHING
 	// 		 SO YOU DON'T NEED TO SET THIS SEPARATELY
 	// Parse local overrides
@@ -574,6 +584,9 @@ func main() {
 		}
 		if proxyRelay != nil {
 			proxyRelay.Stop()
+		}
+		if proxyTCPRelay != nil {
+			proxyTCPRelay.Stop()
 		}
 		return nil
 	})

--- a/main.go
+++ b/main.go
@@ -1665,10 +1665,6 @@ func ensureIFBDevice() error {
 // Bandwidth limit is configurable via the --bandwidth-limit flag or BANDWIDTH_LIMIT env var (default: 50mbit)
 func setupPeerBandwidthLimit(peerIP string) error {
 	logger.Debug("setupPeerBandwidthLimit called for peer IP: %s", peerIP)
-<<<<<<< HEAD
-=======
-
->>>>>>> 06969a4 (Add var for b limit)
 
 	// Parse the IP to get just the IP address (strip any CIDR notation if present)
 	ip := peerIP

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -718,6 +718,7 @@ func (p *SNIProxy) getRoute(hostname, clientAddr string) (*RouteRecord, error) {
 	// Make HTTP request
 	apiStart := time.Now()
 	// Make HTTP request using reusable client
+	apiStart := time.Now()
 	resp, err := p.httpClient.Do(req)
 	if err != nil {
 		metrics.RecordSNIRouteAPIRequest("error")

--- a/relay/tcp_relay.go
+++ b/relay/tcp_relay.go
@@ -1,0 +1,433 @@
+package relay
+
+import (
+	"context"
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+	"net"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/fosrl/gerbil/logger"
+)
+
+type TCPRelayRegistrationMessage struct {
+	Type              string `json:"type"`
+	OlmID             string `json:"olmId"`
+	NewtID            string `json:"newtId"`
+	Token             string `json:"token"`
+	PublicKey         string `json:"publicKey"`
+	ReachableAt       string `json:"reachableAt"`
+	ExitNodePublicKey string `json:"exitNodePublicKey"`
+}
+
+func isTCPRelayRegistrationType(t string) bool {
+	return t == "relay-register" || t == "tcp-relay-register"
+}
+
+// TCPProxyServer accepts framed packets over TCP and forwards them through the
+// same relay logic/path used by UDP.
+type TCPProxyServer struct {
+	addr     string
+	udpProxy *UDPProxyServer
+	listener net.Listener
+	ctx      context.Context
+	cancel   context.CancelFunc
+
+	connections sync.Map // map[string]*DestinationConn where key is destination "ip:port-clientKey"
+}
+
+func NewTCPProxyServer(parentCtx context.Context, addr string, udpProxy *UDPProxyServer) *TCPProxyServer {
+	ctx, cancel := context.WithCancel(parentCtx)
+	return &TCPProxyServer{
+		addr:     addr,
+		udpProxy: udpProxy,
+		ctx:      ctx,
+		cancel:   cancel,
+	}
+}
+
+func (s *TCPProxyServer) Start() error {
+	if s.udpProxy == nil {
+		return fmt.Errorf("udp proxy is required")
+	}
+
+	listener, err := net.Listen("tcp", s.addr)
+	if err != nil {
+		return err
+	}
+	s.listener = listener
+	logger.Info("TCP relay listening on %s", s.addr)
+
+	go s.acceptLoop()
+	go s.cleanupIdleConnections()
+
+	return nil
+}
+
+func (s *TCPProxyServer) Stop() {
+	if s.cancel != nil {
+		s.cancel()
+	}
+	if s.listener != nil {
+		_ = s.listener.Close()
+	}
+	s.connections.Range(func(key, value interface{}) bool {
+		if dc, ok := value.(*DestinationConn); ok && dc.conn != nil {
+			_ = dc.conn.Close()
+		}
+		return true
+	})
+}
+
+func (s *TCPProxyServer) acceptLoop() {
+	for {
+		conn, err := s.listener.Accept()
+		if err != nil {
+			select {
+			case <-s.ctx.Done():
+				return
+			default:
+				logger.Error("TCP relay accept error: %v", err)
+				continue
+			}
+		}
+		go s.handleConnection(conn)
+	}
+}
+
+func (s *TCPProxyServer) handleConnection(conn net.Conn) {
+	defer conn.Close()
+
+	remoteAddr := conn.RemoteAddr().String()
+	logger.Debug("TCP connection from %s", remoteAddr)
+
+	for {
+		select {
+		case <-s.ctx.Done():
+			return
+		default:
+		}
+
+		packet, err := readFramedPacket(conn)
+		if err != nil {
+			logger.Debug("TCP relay connection closed: %s (%v)", remoteAddr, err)
+			return
+		}
+
+		logger.Debug("TCP connection from %s, processing packet (len=%d)", remoteAddr, len(packet))
+		if err := s.processPacket(packet, remoteAddr, func(data []byte) error {
+			return writeFramedPacket(conn, data)
+		}); err != nil {
+			logger.Debug("TCP relay packet processing failed for %s: %v", remoteAddr, err)
+		}
+	}
+}
+
+func (s *TCPProxyServer) processPacket(packet []byte, clientKey string, writeResponse func([]byte) error) error {
+	if len(packet) == 0 {
+		return nil
+	}
+
+	if packet[0] >= 1 && packet[0] <= 4 {
+		s.handleWireGuardPacketTCP(packet, clientKey, writeResponse)
+		return nil
+	}
+
+	// Relay tunnel registration packets are plain JSON and allow the server to
+	// create a proxy mapping for this TCP connection before WireGuard handshakes.
+	var registration TCPRelayRegistrationMessage
+	if err := json.Unmarshal(packet, &registration); err == nil &&
+		isTCPRelayRegistrationType(registration.Type) &&
+		registration.Token != "" &&
+		(registration.OlmID != "" || registration.NewtID != "") {
+		return s.handleRegistration(registration, clientKey)
+	}
+	if err := json.Unmarshal(packet, &registration); err == nil &&
+		isTCPRelayRegistrationType(registration.Type) {
+		logger.Warn(
+			"Rejected TCP relay registration from %s: missing required fields (token=%t olmId=%t newtId=%t)",
+			clientKey,
+			registration.Token != "",
+			registration.OlmID != "",
+			registration.NewtID != "",
+		)
+	}
+
+	var encMsg EncryptedHolePunchMessage
+	if err := json.Unmarshal(packet, &encMsg); err != nil {
+		return fmt.Errorf("unmarshal encrypted hole punch: %w", err)
+	}
+	if encMsg.EphemeralPublicKey == "" {
+		return fmt.Errorf("malformed encrypted hole punch without ephemeral key")
+	}
+
+	decryptedData, err := s.udpProxy.decryptMessage(encMsg)
+	if err != nil {
+		return fmt.Errorf("decrypt hole punch: %w", err)
+	}
+
+	var msg HolePunchMessage
+	if err := json.Unmarshal(decryptedData, &msg); err != nil {
+		return fmt.Errorf("unmarshal hole punch message: %w", err)
+	}
+
+	host, port, err := net.SplitHostPort(clientKey)
+	if err != nil {
+		return fmt.Errorf("split client address: %w", err)
+	}
+	portInt, err := strconv.Atoi(port)
+	if err != nil {
+		return fmt.Errorf("parse client port: %w", err)
+	}
+
+	endpoint := ClientEndpoint{
+		NewtID:            msg.NewtID,
+		OlmID:             msg.OlmID,
+		Token:             msg.Token,
+		IP:                host,
+		Port:              portInt,
+		Timestamp:         time.Now().Unix(),
+		ReachableAt:       s.udpProxy.ReachableAt,
+		ExitNodePublicKey: s.udpProxy.privateKey.PublicKey().String(),
+		ClientPublicKey:   msg.PublicKey,
+	}
+
+	logger.Debug("Created endpoint from TCP client %s: IP=%s, Port=%d", clientKey, endpoint.IP, endpoint.Port)
+	s.udpProxy.notifyServer(endpoint)
+	s.udpProxy.clearSessionsForIP(endpoint.IP)
+	return nil
+}
+
+func (s *TCPProxyServer) handleRegistration(registration TCPRelayRegistrationMessage, clientKey string) error {
+	host, port, err := net.SplitHostPort(clientKey)
+	if err != nil {
+		return fmt.Errorf("split client address: %w", err)
+	}
+	portInt, err := strconv.Atoi(port)
+	if err != nil {
+		return fmt.Errorf("parse client port: %w", err)
+	}
+
+	endpoint := ClientEndpoint{
+		OlmID:             registration.OlmID,
+		NewtID:            registration.NewtID,
+		Token:             registration.Token,
+		IP:                host,
+		Port:              portInt,
+		Timestamp:         time.Now().Unix(),
+		ReachableAt:       registration.ReachableAt,
+		ExitNodePublicKey: registration.ExitNodePublicKey,
+		ClientPublicKey:   registration.PublicKey,
+	}
+
+	logger.Info(
+		"Registered TCP relay client %s for olmId=%s newtId=%s",
+		clientKey,
+		registration.OlmID,
+		registration.NewtID,
+	)
+
+	s.udpProxy.notifyServer(endpoint)
+	s.udpProxy.clearSessionsForIP(endpoint.IP)
+	return nil
+}
+
+func (s *TCPProxyServer) handleWireGuardPacketTCP(packet []byte, clientKey string, writeResponse func([]byte) error) {
+	if len(packet) == 0 {
+		logger.Error("Received empty TCP WireGuard packet")
+		return
+	}
+
+	messageType := packet[0]
+	receiverIndex, senderIndex, ok := extractWireGuardIndices(packet)
+	if !ok {
+		logger.Error("Failed to extract WireGuard indices from TCP packet")
+		return
+	}
+
+	mappingObj, ok := s.udpProxy.proxyMappings.Load(clientKey)
+	if !ok {
+		logger.Debug("TCP relay: no proxy mapping for %s", clientKey)
+		return
+	}
+
+	proxyMapping := mappingObj.(ProxyMapping)
+	logger.Debug(
+		"TCP relay: found proxy mapping for %s with %d destinations",
+		clientKey,
+		len(proxyMapping.Destinations),
+	)
+	proxyMapping.LastUsed = time.Now()
+	s.udpProxy.proxyMappings.Store(clientKey, proxyMapping)
+
+	switch messageType {
+	case WireGuardMessageTypeHandshakeInitiation:
+		for _, dest := range proxyMapping.Destinations {
+			destAddr, err := net.ResolveUDPAddr("udp", fmt.Sprintf("%s:%d", dest.DestinationIP, dest.DestinationPort))
+			if err != nil {
+				logger.Error("Failed to resolve TCP relay destination: %v", err)
+				continue
+			}
+
+			conn, err := s.getOrCreateConnection(destAddr, clientKey, writeResponse)
+			if err != nil {
+				logger.Error("Failed to create TCP relay UDP connection: %v", err)
+				continue
+			}
+
+			if _, err = conn.Write(packet); err != nil {
+				logger.Debug("Failed to forward TCP relay handshake initiation: %v", err)
+			}
+		}
+
+	case WireGuardMessageTypeHandshakeResponse:
+		sessionKey := fmt.Sprintf("%d:%d", receiverIndex, senderIndex)
+		clientAddr, _ := net.ResolveUDPAddr("udp", clientKey)
+		s.udpProxy.wgSessions.Store(sessionKey, &WireGuardSession{
+			ReceiverIndex: receiverIndex,
+			SenderIndex:   senderIndex,
+			DestAddr:      clientAddr,
+			LastSeen:      time.Now(),
+		})
+
+		for _, dest := range proxyMapping.Destinations {
+			destAddr, err := net.ResolveUDPAddr("udp", fmt.Sprintf("%s:%d", dest.DestinationIP, dest.DestinationPort))
+			if err != nil {
+				logger.Error("Failed to resolve TCP relay destination: %v", err)
+				continue
+			}
+
+			conn, err := s.getOrCreateConnection(destAddr, clientKey, writeResponse)
+			if err != nil {
+				logger.Error("Failed to create TCP relay UDP connection: %v", err)
+				continue
+			}
+
+			if _, err = conn.Write(packet); err != nil {
+				logger.Error("Failed to forward TCP relay handshake response: %v", err)
+			}
+		}
+
+	default:
+		for _, dest := range proxyMapping.Destinations {
+			destAddr, err := net.ResolveUDPAddr("udp", fmt.Sprintf("%s:%d", dest.DestinationIP, dest.DestinationPort))
+			if err != nil {
+				logger.Error("Failed to resolve TCP relay destination: %v", err)
+				continue
+			}
+
+			conn, err := s.getOrCreateConnection(destAddr, clientKey, writeResponse)
+			if err != nil {
+				logger.Error("Failed to create TCP relay UDP connection: %v", err)
+				continue
+			}
+
+			if _, err = conn.Write(packet); err != nil {
+				logger.Debug("Failed to forward TCP relay packet: %v", err)
+			}
+		}
+	}
+}
+
+func (s *TCPProxyServer) getOrCreateConnection(destAddr *net.UDPAddr, clientKey string, writeResponse func([]byte) error) (*net.UDPConn, error) {
+	key := destAddr.String() + "-" + clientKey
+	if conn, ok := s.connections.Load(key); ok {
+		destConn := conn.(*DestinationConn)
+		destConn.lastUsed = time.Now()
+		return destConn.conn, nil
+	}
+
+	newConn, err := net.DialUDP("udp", nil, destAddr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create UDP connection: %v", err)
+	}
+
+	s.connections.Store(key, &DestinationConn{
+		conn:     newConn,
+		lastUsed: time.Now(),
+	})
+
+	go s.handleResponses(newConn, key, writeResponse)
+	return newConn, nil
+}
+
+func (s *TCPProxyServer) handleResponses(conn *net.UDPConn, connectionKey string, writeResponse func([]byte) error) {
+	buffer := make([]byte, 1500)
+	for {
+		n, err := conn.Read(buffer)
+		if err != nil {
+			logger.Debug("TCP relay downstream read error on %s: %v", connectionKey, err)
+			return
+		}
+
+		if err := writeResponse(buffer[:n]); err != nil {
+			logger.Debug("TCP relay write response failed on %s: %v", connectionKey, err)
+			return
+		}
+	}
+}
+
+func (s *TCPProxyServer) cleanupIdleConnections() {
+	ticker := time.NewTicker(5 * time.Minute)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			now := time.Now()
+			s.connections.Range(func(key, value interface{}) bool {
+				destConn := value.(*DestinationConn)
+				if now.Sub(destConn.lastUsed) > 10*time.Minute {
+					_ = destConn.conn.Close()
+					s.connections.Delete(key)
+				}
+				return true
+			})
+		case <-s.ctx.Done():
+			return
+		}
+	}
+}
+
+func readFramedPacket(conn net.Conn) ([]byte, error) {
+	header := make([]byte, 4)
+	if _, err := ioReadFull(conn, header); err != nil {
+		return nil, err
+	}
+	length := binary.BigEndian.Uint32(header)
+	if length == 0 || length > 64*1024 {
+		return nil, fmt.Errorf("invalid frame length %d", length)
+	}
+	packet := make([]byte, length)
+	if _, err := ioReadFull(conn, packet); err != nil {
+		return nil, err
+	}
+	return packet, nil
+}
+
+func writeFramedPacket(conn net.Conn, payload []byte) error {
+	if len(payload) == 0 {
+		return nil
+	}
+	header := make([]byte, 4)
+	binary.BigEndian.PutUint32(header, uint32(len(payload)))
+	if _, err := conn.Write(header); err != nil {
+		return err
+	}
+	_, err := conn.Write(payload)
+	return err
+}
+
+func ioReadFull(conn net.Conn, buf []byte) (int, error) {
+	total := 0
+	for total < len(buf) {
+		n, err := conn.Read(buf[total:])
+		total += n
+		if err != nil {
+			return total, err
+		}
+	}
+	return total, nil
+}

--- a/relay/wss_relay.go
+++ b/relay/wss_relay.go
@@ -13,7 +13,7 @@ import (
 	"github.com/fosrl/gerbil/logger"
 )
 
-type TCPRelayRegistrationMessage struct {
+type WssRelayRegistrationMessage struct {
 	Type              string `json:"type"`
 	OlmID             string `json:"olmId"`
 	NewtID            string `json:"newtId"`
@@ -23,13 +23,13 @@ type TCPRelayRegistrationMessage struct {
 	ExitNodePublicKey string `json:"exitNodePublicKey"`
 }
 
-func isTCPRelayRegistrationType(t string) bool {
-	return t == "relay-register" || t == "tcp-relay-register"
+func isWssRelayRegistrationType(t string) bool {
+	return t == "relay-register" || t == "tcp-relay-register" || t == "wss-relay-register"
 }
 
-// TCPProxyServer accepts framed packets over TCP and forwards them through the
-// same relay logic/path used by UDP.
-type TCPProxyServer struct {
+// WssRelayServer accepts framed packets from Pangolin's websocket bridge
+// over TCP and forwards them through the same relay logic/path used by UDP.
+type WssRelayServer struct {
 	addr     string
 	udpProxy *UDPProxyServer
 	listener net.Listener
@@ -39,9 +39,9 @@ type TCPProxyServer struct {
 	connections sync.Map // map[string]*DestinationConn where key is destination "ip:port-clientKey"
 }
 
-func NewTCPProxyServer(parentCtx context.Context, addr string, udpProxy *UDPProxyServer) *TCPProxyServer {
+func NewWssRelayServer(parentCtx context.Context, addr string, udpProxy *UDPProxyServer) *WssRelayServer {
 	ctx, cancel := context.WithCancel(parentCtx)
-	return &TCPProxyServer{
+	return &WssRelayServer{
 		addr:     addr,
 		udpProxy: udpProxy,
 		ctx:      ctx,
@@ -49,7 +49,7 @@ func NewTCPProxyServer(parentCtx context.Context, addr string, udpProxy *UDPProx
 	}
 }
 
-func (s *TCPProxyServer) Start() error {
+func (s *WssRelayServer) Start() error {
 	if s.udpProxy == nil {
 		return fmt.Errorf("udp proxy is required")
 	}
@@ -59,7 +59,7 @@ func (s *TCPProxyServer) Start() error {
 		return err
 	}
 	s.listener = listener
-	logger.Info("TCP relay listening on %s", s.addr)
+	logger.Info("WSS relay listening on %s", s.addr)
 
 	go s.acceptLoop()
 	go s.cleanupIdleConnections()
@@ -67,7 +67,7 @@ func (s *TCPProxyServer) Start() error {
 	return nil
 }
 
-func (s *TCPProxyServer) Stop() {
+func (s *WssRelayServer) Stop() {
 	if s.cancel != nil {
 		s.cancel()
 	}
@@ -82,7 +82,7 @@ func (s *TCPProxyServer) Stop() {
 	})
 }
 
-func (s *TCPProxyServer) acceptLoop() {
+func (s *WssRelayServer) acceptLoop() {
 	for {
 		conn, err := s.listener.Accept()
 		if err != nil {
@@ -90,7 +90,7 @@ func (s *TCPProxyServer) acceptLoop() {
 			case <-s.ctx.Done():
 				return
 			default:
-				logger.Error("TCP relay accept error: %v", err)
+				logger.Error("WSS relay accept error: %v", err)
 				continue
 			}
 		}
@@ -98,11 +98,11 @@ func (s *TCPProxyServer) acceptLoop() {
 	}
 }
 
-func (s *TCPProxyServer) handleConnection(conn net.Conn) {
+func (s *WssRelayServer) handleConnection(conn net.Conn) {
 	defer conn.Close()
 
 	remoteAddr := conn.RemoteAddr().String()
-	logger.Debug("TCP connection from %s", remoteAddr)
+	logger.Debug("WSS relay bridge connection from %s", remoteAddr)
 
 	for {
 		select {
@@ -111,44 +111,44 @@ func (s *TCPProxyServer) handleConnection(conn net.Conn) {
 		default:
 		}
 
-		packet, err := readTCPFramedPacket(conn)
+		packet, err := readFramedPacket(conn)
 		if err != nil {
-			logger.Debug("TCP relay connection closed: %s (%v)", remoteAddr, err)
+			logger.Debug("WSS relay connection closed: %s (%v)", remoteAddr, err)
 			return
 		}
 
-		logger.Debug("TCP connection from %s, processing packet (len=%d)", remoteAddr, len(packet))
+		logger.Debug("WSS relay bridge connection from %s, processing packet (len=%d)", remoteAddr, len(packet))
 		if err := s.processPacket(packet, remoteAddr, func(data []byte) error {
-			return writeTCPFramedPacket(conn, data)
+			return writeFramedPacket(conn, data)
 		}); err != nil {
-			logger.Debug("TCP relay packet processing failed for %s: %v", remoteAddr, err)
+			logger.Debug("WSS relay packet processing failed for %s: %v", remoteAddr, err)
 		}
 	}
 }
 
-func (s *TCPProxyServer) processPacket(packet []byte, clientKey string, writeResponse func([]byte) error) error {
+func (s *WssRelayServer) processPacket(packet []byte, clientKey string, writeResponse func([]byte) error) error {
 	if len(packet) == 0 {
 		return nil
 	}
 
 	if packet[0] >= 1 && packet[0] <= 4 {
-		s.handleWireGuardPacketTCP(packet, clientKey, writeResponse)
+		s.handleWireGuardPacketFramed(packet, clientKey, writeResponse)
 		return nil
 	}
 
 	// Relay tunnel registration packets are plain JSON and allow the server to
 	// create a proxy mapping for this TCP connection before WireGuard handshakes.
-	var registration TCPRelayRegistrationMessage
+	var registration WssRelayRegistrationMessage
 	if err := json.Unmarshal(packet, &registration); err == nil &&
-		isTCPRelayRegistrationType(registration.Type) &&
+		isWssRelayRegistrationType(registration.Type) &&
 		registration.Token != "" &&
 		(registration.OlmID != "" || registration.NewtID != "") {
 		return s.handleRegistration(registration, clientKey)
 	}
 	if err := json.Unmarshal(packet, &registration); err == nil &&
-		isTCPRelayRegistrationType(registration.Type) {
+		isWssRelayRegistrationType(registration.Type) {
 		logger.Warn(
-			"Rejected TCP relay registration from %s: missing required fields (token=%t olmId=%t newtId=%t)",
+			"Rejected WSS relay registration from %s: missing required fields (token=%t olmId=%t newtId=%t)",
 			clientKey,
 			registration.Token != "",
 			registration.OlmID != "",
@@ -195,13 +195,13 @@ func (s *TCPProxyServer) processPacket(packet []byte, clientKey string, writeRes
 		ClientPublicKey:   msg.PublicKey,
 	}
 
-	logger.Debug("Created endpoint from TCP client %s: IP=%s, Port=%d", clientKey, endpoint.IP, endpoint.Port)
+	logger.Debug("Created endpoint from WSS relay bridge client %s: IP=%s, Port=%d", clientKey, endpoint.IP, endpoint.Port)
 	s.udpProxy.notifyServer(endpoint)
 	s.udpProxy.clearSessionsForIP(endpoint.IP)
 	return nil
 }
 
-func (s *TCPProxyServer) handleRegistration(registration TCPRelayRegistrationMessage, clientKey string) error {
+func (s *WssRelayServer) handleRegistration(registration WssRelayRegistrationMessage, clientKey string) error {
 	host, port, err := net.SplitHostPort(clientKey)
 	if err != nil {
 		return fmt.Errorf("split client address: %w", err)
@@ -224,7 +224,7 @@ func (s *TCPProxyServer) handleRegistration(registration TCPRelayRegistrationMes
 	}
 
 	logger.Info(
-		"Registered TCP relay client %s for olmId=%s newtId=%s",
+		"Registered WSS relay client %s for olmId=%s newtId=%s",
 		clientKey,
 		registration.OlmID,
 		registration.NewtID,
@@ -235,28 +235,28 @@ func (s *TCPProxyServer) handleRegistration(registration TCPRelayRegistrationMes
 	return nil
 }
 
-func (s *TCPProxyServer) handleWireGuardPacketTCP(packet []byte, clientKey string, writeResponse func([]byte) error) {
+func (s *WssRelayServer) handleWireGuardPacketFramed(packet []byte, clientKey string, writeResponse func([]byte) error) {
 	if len(packet) == 0 {
-		logger.Error("Received empty TCP WireGuard packet")
+		logger.Error("Received empty framed WireGuard packet")
 		return
 	}
 
 	messageType := packet[0]
 	receiverIndex, senderIndex, ok := extractWireGuardIndices(packet)
 	if !ok {
-		logger.Error("Failed to extract WireGuard indices from TCP packet")
+		logger.Error("Failed to extract WireGuard indices from framed packet")
 		return
 	}
 
 	mappingObj, ok := s.udpProxy.proxyMappings.Load(clientKey)
 	if !ok {
-		logger.Debug("TCP relay: no proxy mapping for %s", clientKey)
+		logger.Debug("WSS relay: no proxy mapping for %s", clientKey)
 		return
 	}
 
 	proxyMapping := mappingObj.(ProxyMapping)
 	logger.Debug(
-		"TCP relay: found proxy mapping for %s with %d destinations",
+		"WSS relay: found proxy mapping for %s with %d destinations",
 		clientKey,
 		len(proxyMapping.Destinations),
 	)
@@ -268,18 +268,18 @@ func (s *TCPProxyServer) handleWireGuardPacketTCP(packet []byte, clientKey strin
 		for _, dest := range proxyMapping.Destinations {
 			destAddr, err := net.ResolveUDPAddr("udp", fmt.Sprintf("%s:%d", dest.DestinationIP, dest.DestinationPort))
 			if err != nil {
-				logger.Error("Failed to resolve TCP relay destination: %v", err)
+				logger.Error("Failed to resolve WSS relay destination: %v", err)
 				continue
 			}
 
 			conn, err := s.getOrCreateConnection(destAddr, clientKey, writeResponse)
 			if err != nil {
-				logger.Error("Failed to create TCP relay UDP connection: %v", err)
+				logger.Error("Failed to create WSS relay UDP connection: %v", err)
 				continue
 			}
 
 			if _, err = conn.Write(packet); err != nil {
-				logger.Debug("Failed to forward TCP relay handshake initiation: %v", err)
+				logger.Debug("Failed to forward WSS relay handshake initiation: %v", err)
 			}
 		}
 
@@ -296,18 +296,18 @@ func (s *TCPProxyServer) handleWireGuardPacketTCP(packet []byte, clientKey strin
 		for _, dest := range proxyMapping.Destinations {
 			destAddr, err := net.ResolveUDPAddr("udp", fmt.Sprintf("%s:%d", dest.DestinationIP, dest.DestinationPort))
 			if err != nil {
-				logger.Error("Failed to resolve TCP relay destination: %v", err)
+				logger.Error("Failed to resolve WSS relay destination: %v", err)
 				continue
 			}
 
 			conn, err := s.getOrCreateConnection(destAddr, clientKey, writeResponse)
 			if err != nil {
-				logger.Error("Failed to create TCP relay UDP connection: %v", err)
+				logger.Error("Failed to create WSS relay UDP connection: %v", err)
 				continue
 			}
 
 			if _, err = conn.Write(packet); err != nil {
-				logger.Error("Failed to forward TCP relay handshake response: %v", err)
+				logger.Error("Failed to forward WSS relay handshake response: %v", err)
 			}
 		}
 
@@ -315,24 +315,24 @@ func (s *TCPProxyServer) handleWireGuardPacketTCP(packet []byte, clientKey strin
 		for _, dest := range proxyMapping.Destinations {
 			destAddr, err := net.ResolveUDPAddr("udp", fmt.Sprintf("%s:%d", dest.DestinationIP, dest.DestinationPort))
 			if err != nil {
-				logger.Error("Failed to resolve TCP relay destination: %v", err)
+				logger.Error("Failed to resolve WSS relay destination: %v", err)
 				continue
 			}
 
 			conn, err := s.getOrCreateConnection(destAddr, clientKey, writeResponse)
 			if err != nil {
-				logger.Error("Failed to create TCP relay UDP connection: %v", err)
+				logger.Error("Failed to create WSS relay UDP connection: %v", err)
 				continue
 			}
 
 			if _, err = conn.Write(packet); err != nil {
-				logger.Debug("Failed to forward TCP relay packet: %v", err)
+				logger.Debug("Failed to forward WSS relay packet: %v", err)
 			}
 		}
 	}
 }
 
-func (s *TCPProxyServer) getOrCreateConnection(destAddr *net.UDPAddr, clientKey string, writeResponse func([]byte) error) (*net.UDPConn, error) {
+func (s *WssRelayServer) getOrCreateConnection(destAddr *net.UDPAddr, clientKey string, writeResponse func([]byte) error) (*net.UDPConn, error) {
 	key := destAddr.String() + "-" + clientKey
 	if conn, ok := s.connections.Load(key); ok {
 		destConn := conn.(*DestinationConn)
@@ -354,23 +354,23 @@ func (s *TCPProxyServer) getOrCreateConnection(destAddr *net.UDPAddr, clientKey 
 	return newConn, nil
 }
 
-func (s *TCPProxyServer) handleResponses(conn *net.UDPConn, connectionKey string, writeResponse func([]byte) error) {
+func (s *WssRelayServer) handleResponses(conn *net.UDPConn, connectionKey string, writeResponse func([]byte) error) {
 	buffer := make([]byte, 1500)
 	for {
 		n, err := conn.Read(buffer)
 		if err != nil {
-			logger.Debug("TCP relay downstream read error on %s: %v", connectionKey, err)
+			logger.Debug("WSS relay downstream read error on %s: %v", connectionKey, err)
 			return
 		}
 
 		if err := writeResponse(buffer[:n]); err != nil {
-			logger.Debug("TCP relay write response failed on %s: %v", connectionKey, err)
+			logger.Debug("WSS relay write response failed on %s: %v", connectionKey, err)
 			return
 		}
 	}
 }
 
-func (s *TCPProxyServer) cleanupIdleConnections() {
+func (s *WssRelayServer) cleanupIdleConnections() {
 	ticker := time.NewTicker(5 * time.Minute)
 	defer ticker.Stop()
 	for {
@@ -391,9 +391,9 @@ func (s *TCPProxyServer) cleanupIdleConnections() {
 	}
 }
 
-func readTCPFramedPacket(conn net.Conn) ([]byte, error) {
+func readFramedPacket(conn net.Conn) ([]byte, error) {
 	header := make([]byte, 4)
-	if _, err := ioReadFullTCP(conn, header); err != nil {
+	if _, err := ioReadFull(conn, header); err != nil {
 		return nil, err
 	}
 	length := binary.BigEndian.Uint32(header)
@@ -401,13 +401,13 @@ func readTCPFramedPacket(conn net.Conn) ([]byte, error) {
 		return nil, fmt.Errorf("invalid frame length %d", length)
 	}
 	packet := make([]byte, length)
-	if _, err := ioReadFullTCP(conn, packet); err != nil {
+	if _, err := ioReadFull(conn, packet); err != nil {
 		return nil, err
 	}
 	return packet, nil
 }
 
-func writeTCPFramedPacket(conn net.Conn, payload []byte) error {
+func writeFramedPacket(conn net.Conn, payload []byte) error {
 	if len(payload) == 0 {
 		return nil
 	}
@@ -420,7 +420,7 @@ func writeTCPFramedPacket(conn net.Conn, payload []byte) error {
 	return err
 }
 
-func ioReadFullTCP(conn net.Conn, buf []byte) (int, error) {
+func ioReadFull(conn net.Conn, buf []byte) (int, error) {
 	total := 0
 	for total < len(buf) {
 		n, err := conn.Read(buf[total:])


### PR DESCRIPTION
## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## What does this PR do?
You can read about the discussion related to this topic here: [Transport flexiblity](https://github.com/orgs/fosrl/discussions/2076)
As discussed, in more restrictive networks UDP connections may be completely blocked and clients are unable to connect to resources. To get around this we use a commonly allowed protocol: HTTPS, or more specifically websockets.

## Description
OLM will try its normal direct UDP/hole punch and UDP relay. If OLM receives a relayEndpointWss (sent with relay info) it starts an 8s timer. Once that timer is up it switches from the shared UDP bind to a websocket bind. Traffic then flows OLM-(wss)->Pangolin-(tcp relay port)->Gerbil->Newt. Now since we are using a websocket the RTT is more than just raw wireguard, and it might be something to look into.

Note: the only thing changed is olm's connection to the gerbil relay, to newt nothing changes.

## How to test?
Setup Pangolin, Gerbil, and Olm from companion PRs mentioned below and regular newt. Have to spin up pangolin, gerbil, newt, and olm to test this. Ideally checking, regular connections, restricted networks, and the force relay flag

## Companion PRs
**Pangolin**: [fosrl/pangolin#2831](https://github.com/fosrl/pangolin/pull/2831)
**Olm**: [fosrl/olm#112](https://github.com/fosrl/olm/pull/112)