### PR TITLE
Upgrade cosign installer to v4.1.2 and pin cosign version

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -107,8 +107,9 @@ jobs:
         shell: bash
 
       - name: Install cosign
-        # cosign is used to sign and verify container images (key and keyless)
-        uses: sigstore/cosign-installer@ba7bc0a3fef59531c69a25acd34668d6d3fe6f22 # v4.1.0
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+        with:
+          cosign-release: v3.0.6
 
       - name: Dual-sign and verify (GHCR & Docker Hub)
         # Sign each image by digest using keyless (OIDC) and key-based signing,


### PR DESCRIPTION
## Description

Updates the Cosign installer workflow usage and explicitly pins the installed Cosign binary to `v3.0.6`.

## Why

Cosign versions below `3.0.6` are affected by CVE-2026-39395. While this workflow was not explicitly pinned to an older vulnerable Cosign binary, the installed Cosign version was implicit and therefore less deterministic.

## Changes

- Updates `sigstore/cosign-installer` to `v4.1.2` https://github.com/sigstore/cosign-installer/releases/tag/v4.1.2
- Adds an explicit `cosign-release: v3.0.6`
- Keeps the workflow behavior unchanged apart from using the fixed Cosign version

## References

- CVE: https://www.suse.com/security/cve/CVE-2026-39395.html
- Cosign installer usage: https://github.com/sigstore/cosign-installer#usage