### PR TITLE
fix(relay): re-notify server on reconnect with unchanged endpoint (clients stuck not registered)

### DIFF
--- a/relay/relay.go
+++ b/relay/relay.go
@@ -416,10 +416,22 @@ func (s *UDPProxyServer) packetWorker() {
 				PublicKey: endpoint.ClientPublicKey,
 			}
 			if cached, ok := s.lastEndpointCache.Load(cacheKey); ok && cached.(cachedEndpointState) == newState {
-				// Endpoint unchanged - skip the HTTP call but still clear stale sessions.
-				logger.Debug("Endpoint unchanged for %s, skipping notification", cacheKey)
+				// Endpoint unchanged - skip the HTTP call for this packet but
+				// still clear stale sessions, and invalidate the cache entry so
+				// the next hole-punch re-notifies the server.
+				//
+				// A reconnecting client (e.g. olm) commonly presents the same
+				// endpoint (same NAT IP:port + persistent public key/token) while
+				// the server has already torn down its session on disconnect. If
+				// we keep skipping notifyServer() in that case, the server never
+				// re-registers the client and never returns a fresh ProxyMapping,
+				// leaving the client stuck "connected but not registered".
+				// Dropping the cache entry here lets the next hole-punch fall
+				// through to notifyServer() and re-establish routing.
+				logger.Debug("Endpoint unchanged for %s, clearing sessions and invalidating cache for re-registration", cacheKey)
 				metrics.RecordHolePunchEvent(relayIfname, "deduplicated")
 				s.clearSessionsForIP(endpoint.IP)
+				s.lastEndpointCache.Delete(cacheKey)
 				metrics.RecordHolePunchEvent(relayIfname, "success")
 				bufferPool.Put(packet.data[:1500])
 				continue


### PR DESCRIPTION
## Problem
Since the hole-punch endpoint dedup (`lastEndpointCache`) was added in 1.4.x, a reconnecting client can get stuck **connected but not registered** indefinitely.

`relay/relay.go` skips `notifyServer()` (`POST /gerbil/update-hole-punch`) whenever the client's endpoint state is unchanged from a cached value:

```go
if cached, ok := s.lastEndpointCache.Load(cacheKey); ok && cached.(cachedEndpointState) == newState {
    // Endpoint unchanged - skip the HTTP call but still clear stale sessions.
    s.clearSessionsForIP(endpoint.IP)
    continue   // notifyServer() skipped
}
```

`notifyServer()` is not just an idempotent update — it is what (re)registers the client and returns the `ProxyMapping` that establishes routing. A reconnecting client (e.g. **olm**) commonly presents the **same** endpoint (same NAT IP:port + a persistent public key/token) while the server has already torn down its session on the previous disconnect. The dedup then suppresses the needed re-registration, so the server never returns a fresh `ProxyMapping` and the client stays in "Registering" forever. Because the cache is in-process, every reconnect from the same endpoint keeps hitting the dedup → the failure is **permanent** until gerbil restarts or the client's endpoint changes.

Observed with gerbil **1.4.0/1.4.1** + olm **1.6.0** (latest) on a remote exit node; olm `/status` shows `connected: true, registered: false, networkSettings: {}`. **gerbil 1.3.1 is unaffected** (no dedup).

## Fix
Invalidate the cache entry in the dedup path (where sessions are already being cleared), so the next hole-punch falls through to `notifyServer()` and re-establishes routing. `notifyServer()` is already asynchronous, so steady-state load stays bounded; this restores the pre-1.4 behaviour of re-notifying on repeated hole-punches.

## Reproduce
1. gerbil 1.4.x on a (remote) exit node.
2. Connect an olm client once (primes `lastEndpointCache`).
3. Disconnect and reconnect from the same NAT endpoint with the same key.
4. Client stays `connected: true, registered: false`; no `ProxyMapping` is created.
- Restarting gerbil lets exactly one subsequent connect register again, then it breaks on the next reconnect — confirming the dedup is the cause.

## Note
Filed as a hotfix PR; a companion issue with the full analysis follows. An alternative (kept-effective dedup) would be to skip only when an active `ProxyMapping` for the client still exists; happy to adjust to whichever the maintainers prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)