### PR TITLE
fix(main): sanitize `remoteConfigURL` to prevent 400 Bad Request on bandwidth reports (#82)

### DIFF
--- a/main.go
+++ b/main.go
@@ -429,9 +429,12 @@ func main() {
 		logger.Fatal("You must provide either a config file or a remote config URL, not both")
 	}
 
-	// clean up the reomte config URL for backwards compatibility
+	// clean up the remote config URL for backwards compatibility
+	remoteConfigURL = strings.TrimRight(remoteConfigURL, "/")
 	remoteConfigURL = strings.TrimSuffix(remoteConfigURL, "/gerbil/get-config")
-	remoteConfigURL = strings.TrimSuffix(remoteConfigURL, "/")
+	remoteConfigURL = strings.TrimSuffix(remoteConfigURL, "/gerbil/receive-bandwidth")
+	remoteConfigURL = strings.TrimSuffix(remoteConfigURL, "/gerbil")
+	remoteConfigURL = strings.TrimRight(remoteConfigURL, "/")
 
 	var key wgtypes.Key
 	// if generateAndSaveKeyTo is provided, generate a private key and save it to the file. if the file already exists, load the key from the file


### PR DESCRIPTION
## Summary

Fixes #82.

After updating to Gerbil v1.4, bandwidth reporting failed every 10 seconds with:

```text
Failed to report peer bandwidth: API returned non-OK status: 400 Bad Request
```

## Root Cause

Gerbil v1.4 changed bandwidth reporting to construct the reporting endpoint dynamically from `remoteConfigURL`:

```go
remoteConfigURL + "/gerbil/receive-bandwidth"
```

The existing sanitization logic in `main.go`:

```go
remoteConfigURL = strings.TrimSuffix(remoteConfigURL, "/gerbil/get-config")
remoteConfigURL = strings.TrimSuffix(remoteConfigURL, "/")
```

failed when `REMOTE_CONFIG` ended with a trailing slash, for example:

```text
http://pangolin:3001/api/v1/gerbil/get-config/
```

In this case:

1. `TrimSuffix(..., "/gerbil/get-config")` failed because of the trailing `/`.
2. `TrimSuffix(..., "/")` only removed the final slash.
3. The URL remained:

```text
http://pangolin:3001/api/v1/gerbil/get-config
```

Gerbil then constructed an invalid endpoint:

```text
http://pangolin:3001/api/v1/gerbil/get-config/gerbil/receive-bandwidth
```

This targeted a non-existent route, causing the server to return **400 Bad Request** every 10 seconds.

## Fix

Updated `remoteConfigURL` sanitization to remove trailing slashes before and after stripping legacy endpoint suffixes.

```go
// Clean up the remote config URL for backwards compatibility.
remoteConfigURL = strings.TrimRight(remoteConfigURL, "/")
remoteConfigURL = strings.TrimSuffix(remoteConfigURL, "/gerbil/get-config")
remoteConfigURL = strings.TrimSuffix(remoteConfigURL, "/gerbil/receive-bandwidth")
remoteConfigURL = strings.TrimSuffix(remoteConfigURL, "/gerbil")
remoteConfigURL = strings.TrimRight(remoteConfigURL, "/")
```

The normalization now correctly handles all supported formats, including:

```text
http://pangolin:3001/api/v1
http://pangolin:3001/api/v1/
http://pangolin:3001/api/v1/gerbil/get-config
http://pangolin:3001/api/v1/gerbil/get-config/
http://pangolin:3001/api/v1/gerbil/receive-bandwidth/
```

All of these normalize to:

```text
http://pangolin:3001/api/v1
```

which results in the correct bandwidth reporting endpoint:

```text
http://pangolin:3001/api/v1/gerbil/receive-bandwidth
```

## Testing

- ✅ Tested `REMOTE_CONFIG` values with and without trailing slashes.
- ✅ Tested legacy `/gerbil/get-config` and `/gerbil/receive-bandwidth` URLs.
- ✅ Verified all configurations normalize to the expected base URL.
- ✅ Confirmed bandwidth reporting succeeds without returning **400 Bad Request**.